### PR TITLE
Use CodeMirror for Code editor and snippets

### DIFF
--- a/cypress/integration/Editor.spec.js
+++ b/cypress/integration/Editor.spec.js
@@ -5,22 +5,23 @@ describe('Code editor', () => {
 		cy.get('button')
 			.contains('Detect', { matchCase: false })
 			.click();
-		cy.get('.v-messages__message')
+		cy.get('.v-snack__content')
 			.contains('required', { matchCase: false })
 			.should('be.visible');
 	});
 	it('should detect code smells', () => {
-		cy.get('textarea')
-			.type('function l(a,b,c,d,e,f,g) {};\nfunction k(a,b,d,e,f,g,h) {}');
+		cy.get('.CodeMirror textarea')
+			.type('function l(a,b,c,d,e,f,g) {};\nfunction k(a,b,d,e,f,g,h) {}', { force: true });
 		cy.get('button')
 			.contains('Detect', { matchCase: false })
 			.click();
 		cy.get('.v-expansion-panels', { timeout: 20000 })
 			.contains('Too many parameters for a function declaration', { matchCase: false })
-			.click()
-			.get('.occurrence-container')
-			.should(($container) => {
-				expect($container).to.have.length(2);
-			});
+			.click();
+		cy.get('.v-expansion-panels')
+			.contains('Too many parameters for a function declaration', { matchCase: false })
+			.parent()
+			.find('.vue-codemirror')
+			.should('have.length', 2);
 	});
 });

--- a/cypress/integration/RepoAnalysis.spec.js
+++ b/cypress/integration/RepoAnalysis.spec.js
@@ -11,6 +11,7 @@ describe('Repo analysis', () => {
 		cy.get('button').contains('Detect', { matchCase: false }).click();
 		cy.get('.v-expansion-panels', { timeout: 20000 })
 			.contains('Line too long', { matchCase: false })
-			.get('.occurrence-container').should('have.descendants', 'code');
+			.parent()
+			.should('have.descendants', '.vue-codemirror');
 	});
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "core-js": "^2.6.5",
     "lodash": "^4.17.15",
     "vue": "^2.6.10",
+    "vue-codemirror": "^4.0.6",
     "vue-markdown": "^2.2.4",
     "vue-router": "^3.1.6",
     "vuetify": "^2.2.11"

--- a/src/components/TheAppBar.vue
+++ b/src/components/TheAppBar.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-		v-app-bar(app, color='green', dark, dense)
+		v-app-bar(class='app-bar', app, color='green', dark, dense)
 			v-toolbar-title
 				router-link(to='/', class='toolbar-title') JavaScript Code Smells Detector
 			v-spacer
@@ -16,6 +16,10 @@ export default {
 </script>
 
 <style lang="scss">
+.app-bar {
+	z-index: 50 !important; // overlay codemirror elements
+}
+
 .toolbar-title {
 	color: white !important;
 	text-decoration: none;

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,22 @@ import Vue from 'vue';
 import App from './App.vue';
 import vuetify from './plugins/vuetify';
 import { router } from './routing';
+import VueCodemirror from 'vue-codemirror';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/addon/dialog/dialog.js';
+import 'codemirror/addon/dialog/dialog.css';
+import 'codemirror/addon/search/jump-to-line';
+import 'codemirror/addon/search/search';
+import 'codemirror/addon/search/match-highlighter';
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/edit/matchbrackets';
+import 'codemirror/addon/hint/show-hint.css';
+import 'codemirror/addon/hint/show-hint.js';
+import 'codemirror/addon/hint/javascript-hint';
+import 'codemirror/addon/selection/active-line';
+import 'codemirror/addon/scroll/simplescrollbars.css';
+import 'codemirror/addon/scroll/simplescrollbars.js';
 
 Vue.config.productionTip = false;
 
@@ -12,6 +28,8 @@ requireComponent.keys().forEach((fileName) => {
 	const componentName = fileName.split('/').pop().replace(/\.\w+$/, '');
 	Vue.component(componentName, componentConfig.default || componentConfig);
 });
+
+Vue.use(VueCodemirror);
 
 new Vue({
 	vuetify,

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,9 +1,3 @@
-@mixin common__code {
-	font-family: Monospace;
-	line-height: 18px;
-	white-space: pre-wrap;
-}
-
 // using copied value to reduce compilation time
 $colors__green-base: #4caf50;
 $colors__grey-lighten-3: #eeeeee;

--- a/src/views/TheCodeEditor.vue
+++ b/src/views/TheCodeEditor.vue
@@ -1,21 +1,33 @@
 <template lang='pug'>
 	v-container(class='fill-height', fluid)
 		v-row(justify='center', no-gutters)
-			v-col(class='d-flex flex-column', md='11', lg='9', xl='8')
-				h3(class='headline font-weight-regular mb-1 align-self-start') Code editor
-				v-form(ref='form')
-					v-textarea(
-						class='editor-textarea',
-						v-model='code',
-						autofocus,
-						color='green',
-						full-width,
-						height='calc(100vh - 230px)',
-						no-resize,
-						outlined,
-						placeholder='Write your code here...',
-						:rules='codeEditorRules',
-						)
+			v-col(class='d-flex flex-column', md='12', lg='10', xl='9')
+				div(class='d-flex justify-space-between align-center mb-1')
+					h3(class='headline font-weight-regular') Code editor
+					v-dialog(v-model='helperDialog', max-width='600')
+						template(#activator='{ on }')
+							v-btn(class='title', color='grey lighten-1', outlined, icon, small, v-on='on') ?
+						v-card
+							v-card-title(class='grey lighten-3') Keybindings
+							v-card-text(class='mt-4 keybindings-content').
+								#[h3 Ctrl-Space]
+								Autocomplete
+								#[h3 Ctrl-F / Cmd-F]
+								Find
+								#[h3 Ctrl-G / Cmd-G]
+								Find next
+								#[h3 Shift-Ctrl-G / Shift-Cmd-G]
+								Find previous
+								#[h3 Shift-Ctrl-F / Cmd-Option-F]
+								Replace
+								#[h3 Shift-Ctrl-R / Shift-Cmd-Option-F]
+								Replace all
+								#[h3 Alt-F]
+								Persistent find (without autoclose, 'Enter' to find next, 'Shift-Enter' to find previous)
+								#[h3 Alt-G]
+								Jump to line
+
+				codemirror(v-model='code', :options='codeMirrorOptions')
 				v-btn(color='green', dark, large, :loading='isLoading', @click='detectSmells') Detect code smells
 
 				div(v-show='!!detectorResult')
@@ -28,20 +40,44 @@
 
 <script>
 import { api } from '../axios';
+import 'codemirror/lib/codemirror.css';
+
+const codeCharactersLimit = 100000;
 
 export default {
 	name: 'TheCodeEditor',
 
 	data: () => ({
 		code: '',
-		codeEditorRules: [value => !!value || 'In order to run detection, it\'s required to provide code.'],
+		codeMirrorOptions: {
+			tabSize: 4,
+			mode: 'text/javascript',
+			extraKeys: {
+				'Ctrl-Space': 'autocomplete',
+				'Alt-F': 'findPersistent',
+			},
+			highlightSelectionMatches: { annotateScrollbar: true },
+			lineNumbers: true,
+			autofocus: true,
+			matchBrackets: true,
+			autoCloseBrackets: true,
+			styleActiveLine: { nonEmpty: true },
+			scrollbarStyle: 'simple',
+		},
 		detectorResult: null,
 		isLoading: false,
+		helperDialog: false,
 	}),
 
 	methods: {
 		detectSmells () {
-			if (!this.$refs.form.validate()) return;
+			if (!this.code) {
+				this.$refs.snackbar.show('Error! In order to run detection, it\'s required to provide code.');
+				return;
+			} else if (this.code.length > codeCharactersLimit) {
+				this.$refs.snackbar.show(`Error! Provided code length is too big. Maximal code length is ${codeCharactersLimit} characters.`);
+				return;
+			}
 			this.isLoading = true;
 
 			api.post('analyze', { code: this.code }).then(res => {
@@ -59,7 +95,27 @@ export default {
 <style lang="scss">
 @import '../styles/common';
 
-.editor-textarea textarea {
-	@include common__code;
+.CodeMirror {
+	height: calc(100vh - 220px);
+	margin-bottom: 24px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+
+	&-focused {
+		border: 1px solid #999;
+	}
+
+	&-selection-highlight-scrollbar {
+		background-color: #97e099;
+		opacity: 0.5;
+	}
+}
+
+.cm-matchhighlight {
+		background-color: #bbecbd;
+}
+
+.keybindings-content h3 {
+	margin-top: 8px;
 }
 </style>

--- a/src/views/TheKnowledgeBase.vue
+++ b/src/views/TheKnowledgeBase.vue
@@ -1,40 +1,39 @@
 <template>
-  <div class="outer-container">
-    <v-navigation-drawer :permanent=true width="400">
-      <v-list dense nav class="py-0">
-			<v-list-item two-line >
-				<v-list-item-content>
-					<v-list-item-title class="list-header">Knowledge Base</v-list-item-title>
-					<v-list-item-subtitle>Available smells</v-list-item-subtitle>
-				</v-list-item-content>
-			</v-list-item>
+	<div class="outer-container">
+		<v-navigation-drawer permanent width="400">
+			<div class='mx-4 mb-2'>
+				<h3 class="title font-weight-medium">Knowledge Base</h3>
+				<h4 class='subtitle font-weight-regular'>Available smells</h4>
+			</div>
 
 			<v-divider></v-divider>
 
-			<v-list-item v-for="item in navSmells" :key="item.title" link :to='"/knowledge-base/" + item.slug'>
-				<v-list-item-content>
-					<v-list-item-title>{{ item.title }}</v-list-item-title>
-				</v-list-item-content>
-			</v-list-item>
-		</v-list>
-	</v-navigation-drawer>
-	<v-container class="content">
-		<p v-show="loading">
-			<v-progress-circular indeterminate color="red"></v-progress-circular>
-		</p>
-		<div v-if="error">
-			<h2>404</h2>
-			<p>The requested page was not found</p>
-			<v-btn to="/">Go back</v-btn>
-		</div>
-		<div v-else-if="content">
-			<vue-markdown v-bind:source="content" />
-		</div>
-		<div v-if="mainPage && !loading">
-			<h1>Knowledge base</h1>
-			<p>Welcome to the knowledge base. Here you can find detailed explanations of code smells that are being detected in your code.</p>
-		</div>
-	</v-container>
+			<v-list dense nav>
+				<v-list-item v-for="item in navSmells" :key="item.title" link :to='"/knowledge-base/" + item.slug'>
+					<v-list-item-content>
+						<v-list-item-title>{{ item.title }}</v-list-item-title>
+					</v-list-item-content>
+				</v-list-item>
+			</v-list>
+		</v-navigation-drawer>
+
+		<v-container class="content">
+			<p v-show="loading">
+				<v-progress-circular indeterminate color="red"></v-progress-circular>
+			</p>
+			<div v-if="error">
+				<h2>404</h2>
+				<p>The requested page was not found</p>
+				<v-btn to="/">Go back</v-btn>
+			</div>
+			<div v-else-if="content">
+				<vue-markdown v-bind:source="content" />
+			</div>
+			<div v-if="mainPage && !loading">
+				<h1>Knowledge base</h1>
+				<p>Welcome to the knowledge base. Here you can find detailed explanations of code smells that are being detected in your code.</p>
+			</div>
+		</v-container>
 </div>
 </template>
 
@@ -100,19 +99,16 @@ export default {
 		height: 100%;
 		display: flex;
 	}
+
 	.content {
 		padding: 32px;
 	}
-	.list-header {
-		font-size: 1.6em;
-		line-height: 1.6em;
-	}
-</style>
-<style>
+
 	.content code::after, .content code::before {
 		content: none;
 	}
-	.content code, .content code{
+
+	.content code, .content code {
 		padding: 8px;
 		margin-top: 10px;
 		width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of changes made by your PR in the title above -->

Linked issues: 
<!--- Use resolves #issue-num syntax -->
Resolves #16, #9.
## Description
<!--- Describe your changes in detail -->
This change introduces CodeMirror, which is widely-used, high-level component mainly for code editing. Usage of most of new features in Code editor is described in "Keybindings" modal visible after clicking "help button" above the editor.

Code editor now has the following features:
- line numbers
- tab indenting
- autocompletion
- syntax highlighting
- highlighting bad smells after detection
- active line styling
- auto-close brackets
- finding/replacing phrases
- jumping to specified fragment of code
- highlighting text similar to the selected one

CodeMirror in read-only mode is also used for snippets in occurrences of code smells.
It has the following features:
- highlighting exact location of code smell
- syntax highlighting
- line numbers (according to location of smell in code)
## Potential TODOS/considerations
<!--- Describe potential improvements. -->
None

